### PR TITLE
changing to mariadb and name dockerfile

### DIFF
--- a/Dockerfile2
+++ b/Dockerfile2
@@ -1,3 +1,0 @@
-FROM mongo:3.4-xenial
-EXPOSE 37017
-

--- a/database.Dockerfile
+++ b/database.Dockerfile
@@ -1,0 +1,3 @@
+FROM mariadb:10.318-bionic
+EXPOSE 37017
+


### PR DESCRIPTION
I've eliminated the file: Dockerfile2 because when we have more than one Dockerfile the name has to be: name.Dockerfile. 
I also changed to mariadb. 